### PR TITLE
Fix module version so it passes validation

### DIFF
--- a/MyModule/MyModule.psd1
+++ b/MyModule/MyModule.psd1
@@ -1,6 +1,6 @@
 @{
 	RootModule = 'MyModule.psm1'
-	ModuleVersion = '1.0.0.0'
+	ModuleVersion = '1.0.0'
 	GUID = '5317f386-975e-41e8-a2d3-2c6bb5efa890'
 	Author = 'Anton Purin'
 	Description = 'Example of PowerShellGet friendly module'


### PR DESCRIPTION
The Demo.ps1 script didn't work for me until I changed the version to match the folder name that Install-Module creates. 

I ran
Test-ModuleManifest C:\Users\<user>\Documents\WindowsPowerShell\Modules\MyModule\1.0.0\MyModule.psd1

and got the error:

Test-ModuleManifest : The ModuleVersion key in module manifest 'C:\Users\<user>\Documents\WindowsPowerShell\Modules\MyModule\1.0.0\MyModule.psd1' specifies module version '1.0.0.0' which does not match its version folder name at
'C:\Users\<user>\Documents\WindowsPowerShell\Modules\MyModule\1.0.0'. Change the value of the ModuleVersion key to match the version folder name.

Fixing the version made Demo.ps1 work properly.